### PR TITLE
Displaying full error logs in UI tests

### DIFF
--- a/tests/portal-integration-tests.groovy
+++ b/tests/portal-integration-tests.groovy
@@ -76,7 +76,7 @@ def execute() {
                         "-e HTTP_PROXY=\"${http_proxy}\" " +
                         "-e HTTPS_PROXY=\"${https_proxy}\" " +
                         "-e MAVEN_OPTS=\"-Duser.home=/build -Dhttp.proxyHost=proxy.intern.est.fujitsu.com -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy.intern.est.fujitsu.com -Dhttps.proxyPort=8080\" " +
-                        "oscm-maven clean install -f /build/oscm-ui-tests/pom.xml"
+                        "oscm-maven clean install -X -f /build/oscm-ui-tests/pom.xml"
             }
         }
     }


### PR DESCRIPTION
Enable full debug logging at Maven using the -X

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-jenkinsscripts/10)
<!-- Reviewable:end -->
