### PR TITLE
 Fix start script for OIDC integration test 

### DIFF
--- a/shared/cleanup.groovy
+++ b/shared/cleanup.groovy
@@ -83,8 +83,8 @@ void execute() {
                 if [ ! -d ${WORKSPACE}/docker ]; then
                     mkdir ${WORKSPACE}/docker;
                 else
-                    docker run --rm -v ${WORKSPACE}/docker:/docker busybox mv /docker/var.env /docker/var.env.bak-jenkins
-                    docker run --rm -v ${WORKSPACE}/docker:/docker busybox mv /docker/.env /docker/.env.bak-jenkins    
+                    docker run --rm -v ${WORKSPACE}/docker:/docker busybox  mv /docker/var.env "/docker/var.env.$(date -Iseconds)"     
+                    docker run --rm -v ${WORKSPACE}/docker:/docker busybox mv /docker/.env "/docker/.env.$(date -Iseconds)"
                 fi;
             fi;
             '''

--- a/shared/start.groovy
+++ b/shared/start.groovy
@@ -52,6 +52,7 @@ void execute(String FQDN = env.NODE_NAME + '.intern.est.fujitsu.com') {
             // (this is because sed needs permission to create a temp file in this directory!)
             sh '''
             docker run --rm -v ${WORKSPACE}/docker:/docker busybox chown $(id -u jenkins):$(id -g jenkins) /docker
+            mkdir -p ${WORKSPACE}/docker/config/oscm-identity/tenants/
             docker run \
                 --name deployer1 \
                 --rm \
@@ -59,6 +60,7 @@ void execute(String FQDN = env.NODE_NAME + '.intern.est.fujitsu.com') {
                 -e SAMPLE_DATA=${SAMPLE_DATA} \
                 ${DOCKER_REGISTRY}/${DOCKER_ORGANIZATION}/oscm-deployer:${DOCKER_TAG}
             '''
+         
         }
     }
 

--- a/shared/start.groovy
+++ b/shared/start.groovy
@@ -45,7 +45,29 @@
 
 void execute(String FQDN = env.NODE_NAME + '.intern.est.fujitsu.com') {
 
-   
+   def _fixPermissionsForTesting = {
+        sh '''
+        
+        if [ ${COMPLETE_CLEANUP} == "false" ]; then
+            mkdir -p ${WORKSPACE}/backup
+            cp -r ${WORKSPACE}/docker/config ${WORKSPACE}/backup
+            cp -r ${WORKSPACE}/docker/data ${WORKSPACE}/backup
+            cp -r ${WORKSPACE}/docker/logs ${WORKSPACE}/backup
+        fi;
+        
+        rm -rf ${WORKSPACE}/docker
+        mkdir -p ${WORKSPACE}/docker/config/oscm-identity/tenants/
+        
+        
+        if [ ${COMPLETE_CLEANUP} == "false" ]; then
+            mkdir -p ${WORKSPACE}/backup
+            cp -r ${WORKSPACE}/backup/config ${WORKSPACE}/docker
+            cp -r ${WORKSPACE}/backup/data ${WORKSPACE}/docker
+            cp -r ${WORKSPACE}/backup/logs ${WORKSPACE}/docker
+            rm -rf ${WORKSPACE}/backup
+        fi;
+        '''
+    }
 
     def _createEnvTemplates = {
         stage('Start - create env templates') {
@@ -152,6 +174,7 @@ void execute(String FQDN = env.NODE_NAME + '.intern.est.fujitsu.com') {
     }
 
    
+    _fixPermissionsForTesting()
     _createEnvTemplates()
     _setupEnv()
     _setupVarEnv()

--- a/shared/start.groovy
+++ b/shared/start.groovy
@@ -45,33 +45,13 @@
 
 void execute(String FQDN = env.NODE_NAME + '.intern.est.fujitsu.com') {
 
-   def _fixPermissionsForTesting = {
-        sh '''
-        
-        if [ ${COMPLETE_CLEANUP} == "false" ]; then
-            mkdir -p ${WORKSPACE}/backup
-            cp -r ${WORKSPACE}/docker/config ${WORKSPACE}/backup
-            cp -r ${WORKSPACE}/docker/data ${WORKSPACE}/backup
-            cp -r ${WORKSPACE}/docker/logs ${WORKSPACE}/backup
-        fi;
-        
-        rm -rf ${WORKSPACE}/docker
-        mkdir -p ${WORKSPACE}/docker/config/oscm-identity/tenants/
-        
-        
-        if [ ${COMPLETE_CLEANUP} == "false" ]; then
-            mkdir -p ${WORKSPACE}/backup
-            cp -r ${WORKSPACE}/backup/config ${WORKSPACE}/docker
-            cp -r ${WORKSPACE}/backup/data ${WORKSPACE}/docker
-            cp -r ${WORKSPACE}/backup/logs ${WORKSPACE}/docker
-            rm -rf ${WORKSPACE}/backup
-        fi;
-        '''
-    }
-
     def _createEnvTemplates = {
         stage('Start - create env templates') {
             sh '''
+            // If the docker dir doesn't exists at this point, it is created with root owner by volume mapping with the docker run command
+            // But we need to change it's owner to jenkins here, in order that env files can be replaced with sed later on
+            // (this is because sed needs permission to create a temp file in this directory!)
+            docker run --rm -v ${WORKSPACE}/docker:/docker busybox chown $(id -u jenkins):$(id -g jenkins) /docker
             docker run \
                 --name deployer1 \
                 --rm \
@@ -172,9 +152,7 @@ void execute(String FQDN = env.NODE_NAME + '.intern.est.fujitsu.com') {
             '''
         }
     }
-
    
-    _fixPermissionsForTesting()
     _createEnvTemplates()
     _setupEnv()
     _setupVarEnv()

--- a/shared/start.groovy
+++ b/shared/start.groovy
@@ -47,10 +47,10 @@ void execute(String FQDN = env.NODE_NAME + '.intern.est.fujitsu.com') {
 
     def _createEnvTemplates = {
         stage('Start - create env templates') {
-            sh '''
             // If the docker dir doesn't exists at this point, it is created with root owner by volume mapping with the docker run command
             // But we need to change it's owner to jenkins here, in order that env files can be replaced with sed later on
             // (this is because sed needs permission to create a temp file in this directory!)
+            sh '''
             docker run --rm -v ${WORKSPACE}/docker:/docker busybox chown $(id -u jenkins):$(id -g jenkins) /docker
             docker run \
                 --name deployer1 \


### PR DESCRIPTION
**Changes in this Pull Request:**
- OIDC integration test fix: Ensure jenkins owner of tenant configuration directory
- Backup env files with timestamp for reentrance 

**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [X] Changes were tested manually
- [ ] Java code changes are unit tested
- [ ] Webtests are successful

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [X] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [X] .MASTER/job/OSCM_WS_Tests_OIDC/
- [X] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [X] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
/view/Docker_OSCM/job/OSCM_Docker_pull_and_start_LG/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-jenkinsscripts/33)
<!-- Reviewable:end -->
