### PR TITLE
Fix Integration tests

### DIFF
--- a/run-integration-tests.groovy
+++ b/run-integration-tests.groovy
@@ -120,6 +120,6 @@ node("${NODE_NAME}") {
     clean.execute()
     pull.execute()
     checkoutTests.execute()
-    start.execute('localhost', false)
+    start.execute('localhost', true)
     tests.execute()
 }


### PR DESCRIPTION
Fix integration tests in OIDC mode. The URL´s are written without ports in the var.env. If we use the proxy, the tests will be successfull again.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-jenkinsscripts/37)
<!-- Reviewable:end -->
