### PR TITLE
Fix oidc mode

### DIFF
--- a/tests/portal-integration-tests.groovy
+++ b/tests/portal-integration-tests.groovy
@@ -56,7 +56,7 @@ def execute() {
                 -e "s|^\\(oidc.authUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/authorize|g" \
                 -e "s|^\\(oidc.logoutUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/logout|g" \
                 -e "s|^\\(oidc.tokenUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/token|g" \
-                -e "s|^\\(oidc.redirectUrl\\+=\\).*|\\1https://localhost:9091/oscm-identity/callback|g" \
+                -e "s|^\\(oidc.redirectUrl\\+=\\).*|\\1https://localhost/oscm-identity/callback|g" \
                 -e "s|^\\(oidc.configurationUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/v2.0/.well-known/openid-configuration|g" \
                 -e "s|^\\(oidc.usersEndpoint\\+=\\).*|\\1https://graph.microsoft.com/v1.0/users|g" \
                 -e "s|^\\(oidc.groupsEndpoint\\+=\\).*|\\1https://graph.microsoft.com/v1.0/groups|g" \

--- a/tests/portal-integration-tests.groovy
+++ b/tests/portal-integration-tests.groovy
@@ -51,8 +51,8 @@ def execute() {
                 sh '''
             sed -i \
                 -e "s|^\\(oidc.provider\\+=\\).*|\\1default|g" \
-                -e "s|^\\(oidc.clientId\\+=\\).*|\\1ef29aa22-369b-424f-9c72-6800fb24239d|g" \
-                -e "s|^\\(oidc.clientSecret\\+=\\).*|\\1ARNRWfZsWiA6A]=tmA-GyRPlhX9=9VQ7|g" \
+                -e "s|^\\(oidc.clientId\\+=\\).*|\\1fd8194f8-6f45-4210-bfcb-647a0e438918|g" \
+                -e "s|^\\(oidc.clientSecret\\+=\\).*|\\1788_tkQ1-LKSio2U3lm4Q~4Xc3K4eZ~6_Y|g" \
                 -e "s|^\\(oidc.authUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/authorize|g" \
                 -e "s|^\\(oidc.logoutUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/logout|g" \
                 -e "s|^\\(oidc.tokenUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/token|g" \
@@ -66,7 +66,6 @@ def execute() {
             }
         }
     }
-    
 
     def _installUITests = {
         stage('Tests - install ui tests') {

--- a/tests/portal-integration-tests.groovy
+++ b/tests/portal-integration-tests.groovy
@@ -52,7 +52,7 @@ def execute() {
             sed -i \
                 -e "s|^\\(oidc.provider\\+=\\).*|\\1default|g" \
                 -e "s|^\\(oidc.clientId\\+=\\).*|\\1fd8194f8-6f45-4210-bfcb-647a0e438918|g" \
-                -e "s|^\\(oidc.clientSecret\\+=\\).*|\\1788_tkQ1-LKSio2U3lm4Q~4Xc3K4eZ~6_Y|g" \
+                -e "s|^\\(oidc.clientSecret\\+=\\).*|\\1buA_sBZmbKVUSa~8n57koKOM-_i0UUII8_|g" \
                 -e "s|^\\(oidc.authUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/authorize|g" \
                 -e "s|^\\(oidc.logoutUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/logout|g" \
                 -e "s|^\\(oidc.tokenUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/token|g" \

--- a/tests/portal-integration-tests.groovy
+++ b/tests/portal-integration-tests.groovy
@@ -51,12 +51,12 @@ def execute() {
                 sh '''
             sed -i \
                 -e "s|^\\(oidc.provider\\+=\\).*|\\1default|g" \
-                -e "s|^\\(oidc.clientId\\+=\\).*|\\152d193b3-0b31-4084-88a6-ea1e065b6bec|g" \
-                -e "s|^\\(oidc.clientSecret\\+=\\).*|\\17F=peZ64RzCeUZRUi3BmgAB.wMMjmo_:|g" \
+                -e "s|^\\(oidc.clientId\\+=\\).*|\\1ef29aa22-369b-424f-9c72-6800fb24239d|g" \
+                -e "s|^\\(oidc.clientSecret\\+=\\).*|\\1ARNRWfZsWiA6A]=tmA-GyRPlhX9=9VQ7|g" \
                 -e "s|^\\(oidc.authUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/authorize|g" \
                 -e "s|^\\(oidc.logoutUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/logout|g" \
                 -e "s|^\\(oidc.tokenUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/oauth2/v2.0/token|g" \
-                -e "s|^\\(oidc.redirectUrl\\+=\\).*|\\1https://localhost/oscm-identity/callback|g" \
+                -e "s|^\\(oidc.redirectUrl\\+=\\).*|\\1https://localhost:9091/oscm-identity/callback|g" \
                 -e "s|^\\(oidc.configurationUrl\\+=\\).*|\\1https://login.microsoftonline.com/ctmgsso.onmicrosoft.com/v2.0/.well-known/openid-configuration|g" \
                 -e "s|^\\(oidc.usersEndpoint\\+=\\).*|\\1https://graph.microsoft.com/v1.0/users|g" \
                 -e "s|^\\(oidc.groupsEndpoint\\+=\\).*|\\1https://graph.microsoft.com/v1.0/groups|g" \
@@ -66,6 +66,7 @@ def execute() {
             }
         }
     }
+    
 
     def _installUITests = {
         stage('Tests - install ui tests') {


### PR DESCRIPTION
Fix Integration tests in OIDC mode. Use OSCM11 as Azure application to authenticate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-jenkinsscripts/39)
<!-- Reviewable:end -->
